### PR TITLE
feat: detect package manager from env

### DIFF
--- a/src/pkg_manager.ts
+++ b/src/pkg_manager.ts
@@ -96,15 +96,26 @@ class Pnpm implements PackageManager {
 
 export type PkgManagerName = "npm" | "yarn" | "pnpm";
 
+function getPkgManagerFromEnv(value: string): PkgManagerName | null {
+  if (value.includes("pnpm/")) return "pnpm";
+  else if (value.includes("yarn/")) return "yarn";
+  else if (value.includes("npm/")) return "npm";
+  else return null;
+}
+
 export async function getPkgManager(
   cwd: string,
   pkgManagerName: PkgManagerName | null
 ) {
-  const { projectDir, pkgManagerName: foundPkgManager } = await findProjectDir(
+  const envPkgManager = process.env.npm_config_user_agent;
+  const fromEnv =
+    envPkgManager !== undefined ? getPkgManagerFromEnv(envPkgManager) : null;
+
+  const { projectDir, pkgManagerName: fromLockfile } = await findProjectDir(
     cwd
   );
 
-  const result = pkgManagerName || foundPkgManager || "npm";
+  const result = pkgManagerName || fromEnv || fromLockfile || "npm";
 
   if (result === "yarn") {
     return new Yarn(projectDir);

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -141,8 +141,13 @@ export function prettyTime(diff: number) {
   return diff + "ms";
 }
 
-export async function exec(cmd: string, args: string[], cwd: string) {
-  const cp = spawn(cmd, args, { stdio: "inherit", cwd, shell: true });
+export async function exec(
+  cmd: string,
+  args: string[],
+  cwd: string,
+  env?: Record<string, string>
+) {
+  const cp = spawn(cmd, args, { stdio: "inherit", cwd, shell: true, env });
 
   return new Promise<void>((resolve) => {
     cp.on("exit", (code) => {

--- a/test/commands.test.ts
+++ b/test/commands.test.ts
@@ -135,6 +135,24 @@ describe("install", () => {
       }
     );
   });
+
+  it("detect pnpm from npm_config_user_agent", async () => {
+    await withTempEnv(
+      ["i", "@std/encoding@0.216.0"],
+      async (_, dir) => {
+        assert.ok(
+          await isFile(path.join(dir, "pnpm-lock.yaml")),
+          "pnpm lockfile not created"
+        );
+      },
+      {
+        env: {
+          ...process.env,
+          npm_config_user_agent: `pnpm/8.14.3 ${process.env.npm_config_user_agent}`,
+        },
+      }
+    );
+  });
 });
 
 describe("remove", () => {


### PR DESCRIPTION
Typically package managers set the environment variable `npm_config_user_agent` with something unique that can be used to identify the package manger jsr was executed with. This allows us to detect `npm` when invoked via `npx` and `pnpm` when invoked via `pnpm dlx` for example.