### PR TITLE
fix: don't overwrite existing jsr registry mapping

### DIFF
--- a/src/commands.ts
+++ b/src/commands.ts
@@ -28,7 +28,7 @@ export async function setupNpmRc(dir: string) {
   const msg = `Setting up ${NPMRC_FILE}`;
   try {
     let content = await fs.promises.readFile(npmRcPath, "utf-8");
-    if (!content.includes(JSR_NPMRC)) {
+    if (!content.includes("@jsr:registry=")) {
       content += JSR_NPMRC;
       await wrapWithStatus(msg, async () => {
         await fs.promises.writeFile(npmRcPath, content);

--- a/test/unit.test.ts
+++ b/test/unit.test.ts
@@ -1,0 +1,23 @@
+import * as path from "path";
+import * as fs from "fs";
+import { runInTempDir } from "./test_utils";
+import { setupNpmRc } from "../src/commands";
+import * as assert from "assert/strict";
+
+describe("npmrc", () => {
+  it("doesn't overwrite exising jsr mapping", async () => {
+    await runInTempDir(async (dir) => {
+      const npmrc = path.join(dir, ".npmrc");
+      await fs.promises.writeFile(
+        npmrc,
+        "@jsr:registry=https://example.com\n",
+        "utf-8",
+      );
+
+      await setupNpmRc(dir);
+
+      const content = await fs.promises.readFile(npmrc, "utf-8");
+      assert.equal(content.trim(), "@jsr:registry=https://example.com");
+    });
+  });
+});


### PR DESCRIPTION
We did only check for the full registry string in `.npmrc` instead of just checking if `@jsr:registry=` was present. This lead to existing values being overwritten by us.