### PR TITLE
feat: don't validate publish arguments

### DIFF
--- a/src/bin.ts
+++ b/src/bin.ts
@@ -71,9 +71,6 @@ ${
         "--token <Token>",
         "The API token to use when publishing. If unset, interactive authentication will be used.",
       ],
-      ["-c, --config <FILE>", "Specify the configuration file."],
-      ["-q, --quiet", "Suppress diagnostic output."],
-      ["--no-config", "Disable automatic loading of the configuration file."],
       [
         "--dry-run",
         "Prepare the package for publishing performing all checks and validations without uploading.",
@@ -83,8 +80,6 @@ ${
         "--provenance",
         "From CI/CD system, publicly links the package to where it was built and published from.",
       ],
-      ["--check[=<CHECK_TYPE>]", "Type-check modules."],
-      ["--no-check[=<NO_CHECK_TYPE>]", "Skip type-checking modules."],
     ])
   }
 
@@ -92,6 +87,10 @@ Environment variables:
 ${
     prettyPrintRow([
       ["JSR_URL", "Use a different registry URL for the publish command."],
+      [
+        "DENO_BIN_PATH",
+        "Use specified Deno binary instead of local downloaded one.",
+      ],
     ])
   }
 `);
@@ -154,7 +153,7 @@ if (args.length === 0) {
         bun: { type: "boolean", default: false },
         debug: { type: "boolean", default: false },
         help: { type: "boolean", default: false, short: "h" },
-        version: { type: "boolean", default: false, short: "-v" },
+        version: { type: "boolean", default: false, short: "v" },
       },
     });
 

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -97,9 +97,7 @@ export async function remove(packages: JsrPackage[], options: BaseOptions) {
 
 export interface PublishOptions {
   binFolder: string;
-  dryRun: boolean;
-  allowSlowTypes: boolean;
-  token: string | undefined;
+  publishArgs: string[];
 }
 
 export async function publish(cwd: string, options: PublishOptions) {
@@ -135,9 +133,8 @@ export async function publish(cwd: string, options: PublishOptions) {
     "publish",
     "--unstable-bare-node-builtins",
     "--unstable-sloppy-imports",
+    "--no-check",
+    ...options.publishArgs,
   ];
-  if (options.dryRun) args.push("--dry-run");
-  if (options.allowSlowTypes) args.push("--allow-slow-types");
-  if (options.token) args.push("--token", options.token);
   await exec(binPath, args, cwd);
 }

--- a/test/commands.test.ts
+++ b/test/commands.test.ts
@@ -298,26 +298,29 @@ describe("publish", () => {
     });
   }).timeout(600000);
 
-  it("use deno binary from DENO_BIN_PATH when set", async () => {
-    await runInTempDir(async (dir) => {
-      await fs.promises.writeFile(
-        path.join(dir, "mod.ts"),
-        "export const value = 42;",
-        "utf-8",
-      );
+  // Windows doesn't support #!/usr/bin/env
+  if (process.platform !== "win32") {
+    it("use deno binary from DENO_BIN_PATH when set", async () => {
+      await runInTempDir(async (dir) => {
+        await fs.promises.writeFile(
+          path.join(dir, "mod.ts"),
+          "export const value = 42;",
+          "utf-8",
+        );
 
-      // TODO: Change this once deno supports jsr.json
-      await writeJson<DenoJson>(path.join(dir, "deno.json"), {
-        name: "@deno/jsr-cli-test",
-        version: "1.0.0",
-        exports: {
-          ".": "./mod.ts",
-        },
-      });
+        // TODO: Change this once deno supports jsr.json
+        await writeJson<DenoJson>(path.join(dir, "deno.json"), {
+          name: "@deno/jsr-cli-test",
+          version: "1.0.0",
+          exports: {
+            ".": "./mod.ts",
+          },
+        });
 
-      await runJsr(["publish", "--dry-run", "--non-existant-option"], dir, {
-        DENO_BIN_PATH: path.join(__dirname, "fixtures", "dummy.js"),
+        await runJsr(["publish", "--dry-run", "--non-existant-option"], dir, {
+          DENO_BIN_PATH: path.join(__dirname, "fixtures", "dummy.js"),
+        });
       });
     });
-  });
+  }
 });

--- a/test/commands.test.ts
+++ b/test/commands.test.ts
@@ -297,4 +297,27 @@ describe("publish", () => {
       await runJsr(["publish", "--dry-run", "--token", "dummy-token"], dir);
     });
   }).timeout(600000);
+
+  it("use deno binary from DENO_BIN_PATH when set", async () => {
+    await runInTempDir(async (dir) => {
+      await fs.promises.writeFile(
+        path.join(dir, "mod.ts"),
+        "export const value = 42;",
+        "utf-8",
+      );
+
+      // TODO: Change this once deno supports jsr.json
+      await writeJson<DenoJson>(path.join(dir, "deno.json"), {
+        name: "@deno/jsr-cli-test",
+        version: "1.0.0",
+        exports: {
+          ".": "./mod.ts",
+        },
+      });
+
+      await runJsr(["publish", "--dry-run", "--non-existant-option"], dir, {
+        DENO_BIN_PATH: path.join(__dirname, "fixtures", "dummy.js"),
+      });
+    });
+  });
 });

--- a/test/fixtures/dummy.js
+++ b/test/fixtures/dummy.js
@@ -1,0 +1,2 @@
+#!/usr/bin/env node
+console.log("it works");


### PR DESCRIPTION
As discussed yesterday, this changes the code to passthrough all arguments to the underlying publish binary without validating them.

Fixes https://github.com/jsr-io/jsr-npm/issues/23