### PR TITLE
feat: add jsr show <pkg> command

### DIFF
--- a/src/api.ts
+++ b/src/api.ts
@@ -1,0 +1,72 @@
+import { JsrPackage } from "./utils";
+
+export const JSR_URL = process.env.JSR_URL ?? "https://jsr.io";
+
+export interface PackageMeta {
+  scope: string;
+  name: string;
+  latest?: string;
+  description?: string;
+  versions: Record<string, {}>;
+}
+
+export async function getPackageMeta(pkg: JsrPackage): Promise<PackageMeta> {
+  const url = `${JSR_URL}/@${pkg.scope}/${pkg.name}/meta.json`;
+  console.log("FETCH", url);
+  const res = await fetch(url);
+  if (!res.ok) {
+    // cancel unconsumed body to avoid memory leak
+    await res.body?.cancel();
+    throw new Error(`Received ${res.status} from ${url}`);
+  }
+
+  return (await res.json()) as PackageMeta;
+}
+
+export async function getLatestPackageVersion(
+  pkg: JsrPackage,
+): Promise<string> {
+  const info = await getPackageMeta(pkg);
+  const { latest } = info;
+  if (latest === undefined) {
+    throw new Error(`Unable to find latest version of ${pkg}`);
+  }
+  return latest;
+}
+
+export interface NpmPackageInfo {
+  name: string;
+  description: string;
+  "dist-tags": { latest: string };
+  versions: Record<string, {
+    name: string;
+    version: string;
+    description: string;
+    dist: {
+      tarball: string;
+      shasum: string;
+      integrity: string;
+    };
+    dependencies: Record<string, string>;
+  }>;
+  time: {
+    created: string;
+    modified: string;
+    [key: string]: string;
+  };
+}
+
+export async function getNpmPackageInfo(
+  pkg: JsrPackage,
+): Promise<NpmPackageInfo> {
+  const tmpUrl = new URL(`${JSR_URL}/@jsr/${pkg.scope}__${pkg.name}`);
+  const url = `${tmpUrl.protocol}//npm.${tmpUrl.host}${tmpUrl.pathname}`;
+  const res = await fetch(url);
+  if (!res.ok) {
+    // Cancel unconsumed body to avoid memory leak
+    await res.body?.cancel();
+    throw new Error(`Received ${res.status} from ${tmpUrl}`);
+  }
+  const json = await res.json();
+  return json as NpmPackageInfo;
+}

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -162,6 +162,6 @@ export async function runScript(
   script: string,
   options: BaseOptions,
 ) {
-  const pkgManager = await getPkgManager(process.cwd(), options.pkgManagerName);
+  const pkgManager = await getPkgManager(cwd, options.pkgManagerName);
   await pkgManager.runScript(script);
 }

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -2,9 +2,16 @@
 import * as path from "node:path";
 import * as fs from "node:fs";
 import * as kl from "kolorist";
-import { exec, fileExists, getNewLineChars, JsrPackage } from "./utils";
+import {
+  exec,
+  fileExists,
+  getNewLineChars,
+  JsrPackage,
+  timeAgo,
+} from "./utils";
 import { Bun, getPkgManager, PkgManagerName, YarnBerry } from "./pkg_manager";
 import { downloadDeno, getDenoDownloadUrl } from "./download";
+import { getNpmPackageInfo, getPackageMeta } from "./api";
 
 const NPMRC_FILE = ".npmrc";
 const BUNFIG_FILE = "bunfig.toml";
@@ -164,4 +171,41 @@ export async function runScript(
 ) {
   const pkgManager = await getPkgManager(cwd, options.pkgManagerName);
   await pkgManager.runScript(script);
+}
+
+export async function showPackageInfo(raw: string) {
+  const pkg = JsrPackage.from(raw);
+
+  const meta = await getPackageMeta(pkg);
+  if (pkg.version === null) {
+    if (meta.latest === undefined) {
+      throw new Error(`Missing latest version for ${pkg}`);
+    }
+    pkg.version = meta.latest!;
+  }
+
+  const versionCount = Object.keys(meta.versions).length;
+
+  const npmInfo = await getNpmPackageInfo(pkg);
+
+  const versionInfo = npmInfo.versions[pkg.version]!;
+  const time = npmInfo.time[pkg.version];
+
+  const publishTime = new Date(time).getTime();
+
+  console.log();
+  console.log(
+    kl.cyan(`@${pkg.scope}/${pkg.name}@${pkg.version}`) +
+      ` | latest: ${kl.magenta(meta.latest ?? "-")} | versions: ${
+        kl.magenta(versionCount)
+      }`,
+  );
+  console.log(npmInfo.description);
+  console.log();
+  console.log(`npm tarball:   ${kl.cyan(versionInfo.dist.tarball)}`);
+  console.log(`npm integrity: ${kl.cyan(versionInfo.dist.integrity)}`);
+  console.log();
+  console.log(
+    `published: ${kl.magenta(timeAgo(Date.now() - publishTime))}`,
+  );
 }

--- a/src/pkg_manager.ts
+++ b/src/pkg_manager.ts
@@ -1,9 +1,8 @@
 // Copyright 2024 the JSR authors. MIT license.
+import { getLatestPackageVersion } from "./api";
 import { InstallOptions } from "./commands";
 import { exec, findProjectDir, JsrPackage, logDebug } from "./utils";
 import * as kl from "kolorist";
-
-const JSR_URL = "https://jsr.io";
 
 async function execWithLog(cmd: string, args: string[], cwd: string) {
   console.log(kl.dim(`$ ${cmd} ${args.join(" ")}`));
@@ -41,22 +40,6 @@ async function isYarnBerry(cwd: string) {
   }
   logDebug("Detected yarn berry from version");
   return true;
-}
-
-async function getLatestPackageVersion(pkg: JsrPackage) {
-  const url = `${JSR_URL}/${pkg}/meta.json`;
-  const res = await fetch(url);
-  if (!res.ok) {
-    // cancel the response body here in order to avoid a potential memory leak in node:
-    // https://github.com/nodejs/undici/tree/c47e9e06d19cf61b2fa1fcbfb6be39a6e3133cab/docs#specification-compliance
-    await res.body?.cancel();
-    throw new Error(`Received ${res.status} from ${url}`);
-  }
-  const { latest } = await res.json();
-  if (!latest) {
-    throw new Error(`Unable to find latest version of ${pkg}`);
-  }
-  return latest;
 }
 
 export interface PackageManager {

--- a/test/commands.test.ts
+++ b/test/commands.test.ts
@@ -1,5 +1,6 @@
 import * as path from "path";
 import * as fs from "fs";
+import * as kl from "kolorist";
 import {
   DenoJson,
   enableYarnBerry,
@@ -544,5 +545,33 @@ describe("run", () => {
 
       await runJsr(["test"], dir);
     });
+  });
+});
+
+describe("show", () => {
+  it("should show package information", async () => {
+    const output = await runJsr(
+      ["show", "@std/encoding"],
+      process.cwd(),
+      undefined,
+      true,
+    );
+    const txt = kl.stripColors(output);
+    assert.ok(txt.includes("latest:"));
+    assert.ok(txt.includes("npm tarball:"));
+  });
+
+  it("can use 'view' alias", async () => {
+    await runJsr(
+      ["view", "@std/encoding"],
+      process.cwd(),
+    );
+  });
+
+  it("can use 'info' alias", async () => {
+    await runJsr(
+      ["view", "@std/encoding"],
+      process.cwd(),
+    );
   });
 });

--- a/test/test_utils.ts
+++ b/test/test_utils.ts
@@ -33,6 +33,7 @@ export async function runJsr(
   args: string[],
   cwd: string,
   env: Record<string, string> = {},
+  captureOutput = false,
 ) {
   const bin = path.join(__dirname, "..", "src", "bin.ts");
   const tsNode = path.join(__dirname, "..", "node_modules", ".bin", "ts-node");
@@ -40,7 +41,7 @@ export async function runJsr(
     ...process.env,
     npm_config_user_agent: undefined,
     ...env,
-  });
+  }, captureOutput);
 }
 
 export async function runInTempDir(fn: (dir: string) => Promise<void>) {


### PR DESCRIPTION
Similar to npm's `show` command this PR adds the same functionality to `jsr`. The output is slightly different since we have a different subset of information in our database.

<img width="803" alt="Screenshot 2024-03-06 at 15 11 57" src="https://github.com/jsr-io/jsr-npm/assets/1062408/3284acb5-d41f-416a-9721-2be511db2f1a">
