### PR TITLE
chore: Remove getPkgJson test function

### DIFF
--- a/src/api.ts
+++ b/src/api.ts
@@ -12,7 +12,6 @@ export interface PackageMeta {
 
 export async function getPackageMeta(pkg: JsrPackage): Promise<PackageMeta> {
   const url = `${JSR_URL}/@${pkg.scope}/${pkg.name}/meta.json`;
-  console.log("FETCH", url);
   const res = await fetch(url);
   if (!res.ok) {
     // cancel unconsumed body to avoid memory leak

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -227,3 +227,40 @@ export function getNewLineChars(source: string) {
   }
   return "\n";
 }
+
+export async function readJson<T>(file: string): Promise<T> {
+  const content = await fs.promises.readFile(file, "utf-8");
+  return JSON.parse(content);
+}
+
+export interface PkgJson {
+  name?: string;
+  version?: string;
+  license?: string;
+
+  dependencies?: Record<string, string>;
+  devDependencies?: Record<string, string>;
+  optionalDependencies?: Record<string, string>;
+  exports?: string | Record<string, string | Record<string, string>>;
+  scripts?: Record<string, string>;
+}
+
+export async function writeJson<T>(file: string, data: T): Promise<void> {
+  try {
+    await fs.promises.mkdir(path.dirname(file), { recursive: true });
+  } catch (_) {}
+  await fs.promises.writeFile(file, JSON.stringify(data, null, 2), "utf-8");
+}
+
+export async function readTextFile(file: string): Promise<string> {
+  return fs.promises.readFile(file, "utf-8");
+}
+export async function writeTextFile(
+  file: string,
+  content: string,
+): Promise<void> {
+  try {
+    await fs.promises.mkdir(path.dirname(file), { recursive: true });
+  } catch (_) {}
+  await fs.promises.writeFile(file, content, "utf-8");
+}

--- a/test/test_utils.ts
+++ b/test/test_utils.ts
@@ -1,19 +1,7 @@
 import * as fs from "node:fs";
 import * as path from "node:path";
 import * as os from "node:os";
-import { exec } from "../src/utils";
-
-export interface PkgJson {
-  name: string;
-  version: string;
-  license: string;
-
-  dependencies?: Record<string, string>;
-  devDependencies?: Record<string, string>;
-  optionalDependencies?: Record<string, string>;
-  exports?: string | Record<string, string | Record<string, string>>;
-  scripts?: Record<string, string>;
-}
+import { exec, writeJson } from "../src/utils";
 
 export interface DenoJson {
   name: string;
@@ -61,14 +49,12 @@ export async function runInTempDir(fn: (dir: string) => Promise<void>) {
 
 export async function withTempEnv(
   args: string[],
-  fn: (getPkgJson: () => Promise<PkgJson>, dir: string) => Promise<void>,
+  fn: (dir: string) => Promise<void>,
   options: { env?: Record<string, string> } = {},
 ): Promise<void> {
   await runInTempDir(async (dir) => {
     await runJsr(args, dir, options.env);
-    const pkgJson = async () =>
-      readJson<PkgJson>(path.join(dir, "package.json"));
-    await fn(pkgJson, dir);
+    await fn(dir);
   });
 }
 
@@ -86,13 +72,4 @@ export async function isFile(path: string): Promise<boolean> {
   } catch (err) {
     return false;
   }
-}
-
-export async function readJson<T>(file: string): Promise<T> {
-  const content = await fs.promises.readFile(file, "utf-8");
-  return JSON.parse(content);
-}
-
-export async function writeJson<T>(file: string, data: T): Promise<void> {
-  await fs.promises.writeFile(file, JSON.stringify(data, null, 2), "utf-8");
 }

--- a/test/unit.test.ts
+++ b/test/unit.test.ts
@@ -1,22 +1,18 @@
 import * as path from "path";
-import * as fs from "fs";
 import { runInTempDir } from "./test_utils";
 import { setupNpmRc } from "../src/commands";
 import * as assert from "assert/strict";
+import { readTextFile, writeTextFile } from "../src/utils";
 
 describe("npmrc", () => {
   it("doesn't overwrite exising jsr mapping", async () => {
     await runInTempDir(async (dir) => {
       const npmrc = path.join(dir, ".npmrc");
-      await fs.promises.writeFile(
-        npmrc,
-        "@jsr:registry=https://example.com\n",
-        "utf-8",
-      );
+      await writeTextFile(npmrc, "@jsr:registry=https://example.com\n");
 
       await setupNpmRc(dir);
 
-      const content = await fs.promises.readFile(npmrc, "utf-8");
+      const content = await readTextFile(npmrc);
       assert.equal(content.trim(), "@jsr:registry=https://example.com");
     });
   });
@@ -24,15 +20,11 @@ describe("npmrc", () => {
   it("adds newline in between entries if necessary", async () => {
     await runInTempDir(async (dir) => {
       const npmrc = path.join(dir, ".npmrc");
-      await fs.promises.writeFile(
-        npmrc,
-        "@foo:registry=https://example.com",
-        "utf-8",
-      );
+      await writeTextFile(npmrc, "@foo:registry=https://example.com");
 
       await setupNpmRc(dir);
 
-      const content = await fs.promises.readFile(npmrc, "utf-8");
+      const content = await readTextFile(npmrc);
       assert.equal(
         content.trim(),
         [

--- a/test/utils.test.ts
+++ b/test/utils.test.ts
@@ -1,17 +1,12 @@
 import * as assert from "assert/strict";
-import * as fs from "fs";
 import * as path from "node:path";
-import { runInTempDir, writeJson } from "./test_utils";
-import { findProjectDir } from "../src/utils";
+import { runInTempDir } from "./test_utils";
+import { findProjectDir, writeJson, writeTextFile } from "../src/utils";
 
 describe("findProjectDir", () => {
   it("should return npm if package-lock.json is found", async () => {
     await runInTempDir(async (tempDir) => {
-      await fs.promises.writeFile(
-        path.join(tempDir, "package-lock.json"),
-        "{}",
-        "utf-8",
-      );
+      await writeTextFile(path.join(tempDir, "package-lock.json"), "{}");
       const result = await findProjectDir(tempDir);
       assert.strictEqual(result.pkgManagerName, "npm");
     });
@@ -19,7 +14,7 @@ describe("findProjectDir", () => {
 
   it("should return yarn if yarn.lock is found", async () => {
     await runInTempDir(async (tempDir) => {
-      await fs.promises.writeFile(path.join(tempDir, "yarn.lock"), "", "utf-8");
+      await writeTextFile(path.join(tempDir, "yarn.lock"), "");
       const result = await findProjectDir(tempDir);
       assert.strictEqual(result.pkgManagerName, "yarn");
     });
@@ -27,11 +22,7 @@ describe("findProjectDir", () => {
 
   it("should return pnpm if pnpm-lock.yaml is found", async () => {
     await runInTempDir(async (tempDir) => {
-      await fs.promises.writeFile(
-        path.join(tempDir, "pnpm-lock.yaml"),
-        "",
-        "utf-8",
-      );
+      await writeTextFile(path.join(tempDir, "pnpm-lock.yaml"), "");
       const result = await findProjectDir(tempDir);
       assert.strictEqual(result.pkgManagerName, "pnpm");
     });
@@ -39,7 +30,7 @@ describe("findProjectDir", () => {
 
   it("should return bun if bun.lockb is found", async () => {
     await runInTempDir(async (tempDir) => {
-      await fs.promises.writeFile(path.join(tempDir, "bun.lockb"), "", "utf-8");
+      await writeTextFile(path.join(tempDir, "bun.lockb"), "");
       const result = await findProjectDir(tempDir);
       assert.strictEqual(result.pkgManagerName, "bun");
     });
@@ -49,8 +40,8 @@ describe("findProjectDir", () => {
     // bun allow to save bun.lockb and yarn.lock
     // https://bun.sh/docs/install/lockfile
     await runInTempDir(async (tempDir) => {
-      await fs.promises.writeFile(path.join(tempDir, "bun.lockb"), "", "utf-8");
-      await fs.promises.writeFile(path.join(tempDir, "yarn.lock"), "", "utf-8");
+      await writeTextFile(path.join(tempDir, "bun.lockb"), "");
+      await writeTextFile(path.join(tempDir, "yarn.lock"), "");
       const result = await findProjectDir(tempDir);
       assert.strictEqual(result.pkgManagerName, "bun");
     });
@@ -59,7 +50,6 @@ describe("findProjectDir", () => {
   it("should set project dir to nearest package.json", async () => {
     await runInTempDir(async (tempDir) => {
       const sub = path.join(tempDir, "sub");
-      await fs.promises.mkdir(sub);
 
       await writeJson(path.join(tempDir, "package.json"), {});
       await writeJson(path.join(sub, "package.json"), {});


### PR DESCRIPTION
This refactors the test setup to be more consistent. Previously, we had a `getPkgJson()` function which was a bit special. We can replace that with a simple `readJson()` instead that we're already using elsewhere. That way there are no "special" functions used anymore.