### PR TITLE
feat: set DENO_DISABLE_PEDANTIC_NODE_WARNINGS during publish by default

### DIFF
--- a/src/commands.ts
+++ b/src/commands.ts
@@ -161,7 +161,10 @@ export async function publish(cwd: string, options: PublishOptions) {
     "--no-check",
     ...options.publishArgs,
   ];
-  await exec(binPath, args, cwd);
+  await exec(binPath, args, cwd, {
+    ...process.env,
+    DENO_DISABLE_PEDANTIC_NODE_WARNINGS: "true",
+  });
 }
 
 export async function runScript(


### PR DESCRIPTION
Hide errors we can fix ourselves during publish like sloppy imports. See https://github.com/denoland/deno/pull/22760