### PR TITLE
fix: `--npm` flag not being respected

### DIFF
--- a/src/bin.ts
+++ b/src/bin.ts
@@ -196,6 +196,8 @@ if (args.length === 0) {
       ? "yarn"
       : options.values.bun
       ? "bun"
+      : options.values.npm
+      ? "npm"
       : null;
 
     if (cmd === "i" || cmd === "install" || cmd === "add") {

--- a/test/commands.test.ts
+++ b/test/commands.test.ts
@@ -336,6 +336,25 @@ describe("install", () => {
       );
     });
 
+    it("overwrite detection with arg from npm_config_user_agent", async () => {
+      await withTempEnv(
+        ["i", "--npm", "@std/encoding@0.216.0"],
+        async (dir) => {
+          assert.ok(
+            await isFile(path.join(dir, "package-lock.json")),
+            "npm lockfile not created",
+          );
+        },
+        {
+          env: {
+            ...process.env,
+            npm_config_user_agent:
+              `pnpm/8.14.3 ${process.env.npm_config_user_agent}`,
+          },
+        },
+      );
+    });
+
     it("detect yarn from npm_config_user_agent", async () => {
       await withTempEnv(
         ["i", "@std/encoding@0.216.0"],


### PR DESCRIPTION
We missed a branch for forcing `npm` when `--npm` is set and were falling back to whatever we were called with instead. This PR fixes that.