### PR TITLE
feat: support -g, --global install arg

### DIFF
--- a/src/bin.ts
+++ b/src/bin.ts
@@ -11,7 +11,13 @@ import {
   runScript,
   showPackageInfo,
 } from "./commands";
-import { JsrPackage, JsrPackageNameError, prettyTime, setDebug } from "./utils";
+import {
+  JsrPackage,
+  JsrPackageNameError,
+  NpmPackage,
+  prettyTime,
+  setDebug,
+} from "./utils";
 import { PkgManagerName } from "./pkg_manager";
 
 const args = process.argv.slice(2);
@@ -63,6 +69,7 @@ ${
       ],
       ["-D, --save-dev", "Package will be added to devDependencies."],
       ["-O, --save-optional", "Package will be added to optionalDependencies."],
+      ["-g, --global", "Install packages globally."],
       ["--npm", "Use npm to remove and install packages."],
       ["--yarn", "Use yarn to remove and install packages."],
       ["--pnpm", "Use pnpm to remove and install packages."],
@@ -105,9 +112,19 @@ ${
 `);
 }
 
-function getPackages(positionals: string[]): JsrPackage[] {
+function getPackages(positionals: string[]): Array<JsrPackage | NpmPackage> {
   const pkgArgs = positionals.slice(1);
-  const packages = pkgArgs.map((p) => JsrPackage.from(p));
+  const packages = pkgArgs.map((p) => {
+    try {
+      return JsrPackage.from(p);
+    } catch (_) {
+      try {
+        return NpmPackage.from(p);
+      } catch (_) {
+        throw new Error(`Invalid jsr or npm package name: ${p}`);
+      }
+    }
+  });
 
   if (pkgArgs.length === 0) {
     console.error(kl.red(`Missing packages argument.`));
@@ -167,6 +184,7 @@ if (args.length === 0) {
         "allow-slow-types": { type: "boolean", default: false },
         token: { type: "string" },
         config: { type: "string", short: "c" },
+        global: { type: "boolean", short: "g" },
         "no-config": { type: "boolean" },
         check: { type: "string" },
         "no-check": { type: "string" },
@@ -207,6 +225,7 @@ if (args.length === 0) {
             : options.values["save-optional"]
             ? "optional"
             : "prod",
+          global: options.values.global ?? false,
           pkgManagerName,
         });
       });

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -7,6 +7,7 @@ import {
   fileExists,
   getNewLineChars,
   JsrPackage,
+  NpmPackage,
   timeAgo,
 } from "./utils";
 import { Bun, getPkgManager, PkgManagerName, YarnBerry } from "./pkg_manager";
@@ -84,9 +85,13 @@ export interface BaseOptions {
 
 export interface InstallOptions extends BaseOptions {
   mode: "dev" | "prod" | "optional";
+  global: boolean;
 }
 
-export async function install(packages: JsrPackage[], options: InstallOptions) {
+export async function install(
+  packages: Array<JsrPackage | NpmPackage>,
+  options: InstallOptions,
+) {
   const pkgManager = await getPkgManager(process.cwd(), options.pkgManagerName);
 
   if (pkgManager instanceof Bun) {
@@ -107,7 +112,10 @@ export async function install(packages: JsrPackage[], options: InstallOptions) {
   await pkgManager.install(packages, options);
 }
 
-export async function remove(packages: JsrPackage[], options: BaseOptions) {
+export async function remove(
+  packages: Array<JsrPackage | NpmPackage>,
+  options: BaseOptions,
+) {
   const pkgManager = await getPkgManager(process.cwd(), options.pkgManagerName);
   console.log(`Removing ${kl.cyan(packages.join(", "))}...`);
   await pkgManager.remove(packages);

--- a/test/unit.test.ts
+++ b/test/unit.test.ts
@@ -2,7 +2,7 @@ import * as path from "path";
 import { runInTempDir } from "./test_utils";
 import { setupNpmRc } from "../src/commands";
 import * as assert from "assert/strict";
-import { readTextFile, writeTextFile } from "../src/utils";
+import { NpmPackage, readTextFile, writeTextFile } from "../src/utils";
 
 describe("npmrc", () => {
   it("doesn't overwrite exising jsr mapping", async () => {
@@ -33,5 +33,24 @@ describe("npmrc", () => {
         ].join("\n"),
       );
     });
+  });
+});
+
+describe("NpmPackage", () => {
+  it("parse", () => {
+    assert.equal(NpmPackage.from("foo").toString(), "foo");
+    assert.equal(NpmPackage.from("foo-bar").toString(), "foo-bar");
+    assert.equal(
+      NpmPackage.from("@foo-bar/foo-bar").toString(),
+      "@foo-bar/foo-bar",
+    );
+    assert.equal(
+      NpmPackage.from("@foo-bar@1.0.0").toString(),
+      "@foo-bar@1.0.0",
+    );
+    assert.equal(
+      NpmPackage.from("@foo-bar/baz@1.0.0").toString(),
+      "@foo-bar/baz@1.0.0",
+    );
   });
 });


### PR DESCRIPTION
This PR adds support for installing packages globally via `jsr i -g <package>`. This allows `jsr` to self update via `jsr i -g jsr` for example.

Not sure how to write tests for this as the other package managers don't seem to have a way to temporarily overwrite the global install location.

Fixes https://github.com/jsr-io/jsr-npm/issues/46