### PR TITLE
feat: Set --unstable-byonm during publishing by default

### DIFF
--- a/src/commands.ts
+++ b/src/commands.ts
@@ -158,6 +158,7 @@ export async function publish(cwd: string, options: PublishOptions) {
     "publish",
     "--unstable-bare-node-builtins",
     "--unstable-sloppy-imports",
+    "--unstable-byonm",
     "--no-check",
     ...options.publishArgs,
   ];


### PR DESCRIPTION
Currently, when publishing to JSR Deno replaces the structure in `node_modules` with the deno-specific one which requires installing all dependencies again. This is not necessary and feels wrong to mess with during publish.

This PR changes the behavior so that Deno leaves the `node_modules` folder as is.