### PR TITLE
fix: wrong project folder detection

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -82,6 +82,18 @@ export async function findProjectDir(
     pkgJsonPath: null,
   },
 ): Promise<ProjectInfo> {
+  // Ensure we check for `package.json` first as this defines
+  // the root project location.
+  if (result.pkgJsonPath === null) {
+    const pkgJsonPath = path.join(dir, "package.json");
+    if (await fileExists(pkgJsonPath)) {
+      logDebug(`Found package.json at ${pkgJsonPath}`);
+      logDebug(`Setting project directory to ${dir}`);
+      result.projectDir = dir;
+      result.pkgJsonPath = pkgJsonPath;
+    }
+  }
+
   const npmLockfile = path.join(dir, "package-lock.json");
   if (await fileExists(npmLockfile)) {
     logDebug(`Detected npm from lockfile ${npmLockfile}`);
@@ -111,15 +123,6 @@ export async function findProjectDir(
     logDebug(`Detected pnpm from lockfile ${pnpmLockfile}`);
     result.pkgManagerName = "pnpm";
     return result;
-  }
-
-  if (result.pkgJsonPath === null) {
-    const pkgJsonPath = path.join(dir, "package.json");
-    if (await fileExists(pkgJsonPath)) {
-      logDebug(`Found package.json at ${pkgJsonPath}`);
-      result.projectDir = dir;
-      result.pkgJsonPath = pkgJsonPath;
-    }
   }
 
   const prev = dir;

--- a/test/commands.test.ts
+++ b/test/commands.test.ts
@@ -12,6 +12,7 @@ import {
 } from "./test_utils";
 import * as assert from "node:assert/strict";
 import {
+  exec,
   PkgJson,
   readJson,
   readTextFile,
@@ -287,6 +288,23 @@ describe("install", () => {
         );
       },
     );
+  });
+
+  it("pnpm install into existing project", async () => {
+    await runInTempDir(async (dir) => {
+      const sub = path.join(dir, "sub", "sub1");
+      await fs.promises.mkdir(sub, {
+        recursive: true,
+      });
+
+      await exec("pnpm", ["i", "preact"], dir);
+
+      await runJsr(["i", "--pnpm", "@std/encoding@0.216.0"], sub);
+      assert.ok(
+        await isFile(path.join(dir, "pnpm-lock.yaml")),
+        "pnpm lockfile not created",
+      );
+    });
   });
 
   if (process.platform !== "win32") {


### PR DESCRIPTION
This PR fixes an issue where we didn't detect the project directory properly when `jsr` was executing inside a subfolder of an existing project. In our upwards traversal function we checked for the lockfile first and bailed out if we found one. This means the code that sets the project directory was never executed if a lockfile had already been found.

Fixes https://github.com/jsr-io/jsr-npm/issues/56