### PR TITLE
fix: Build `dist-esm` before publishing release on npm

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "test": "mocha -r ts-node/register --extensions ts,tsx --timeout 30000 --watch-files src,test 'test/**/*.test.ts'",
     "cli": "ts-node src/bin.ts",
     "build": "rimraf dist dist-esm && tsc && tsc -p tsconfig.esm.json",
-    "prepublishOnly": "tsc"
+    "prepublishOnly": "npm run build"
   },
   "keywords": [
     "install",


### PR DESCRIPTION
I am currently trying to use this module automatically. I have noticed that the `dist-esm` folder specified in `package.json` [does not exist](https://www.npmjs.com/package/jsr?activeTab=code). I looked at the GitHub Action workflow file and saw that only [`npm publish` is called here](https://github.com/jsr-io/jsr-npm/blob/main/.github/workflows/release.yml#L16). Within the `package.json`, however, only `tsc` is called in the `prepublishOnly` script, not `tsc -p tsconfig.esm.json`, which is responsible for the ESM build. I have adapted the line so that `npm run build` is now executed (whch executes both builds).

I hope that this fixes the problem in the next release and would of course be delighted if this happes soon. Thank you.