### PR TITLE
feat: add --from-jsr-config option

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7,9 +7,9 @@
     "": {
       "name": "jsr",
       "version": "0.12.1",
-      "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
+        "jsonc-parser": "^3.2.1",
         "kolorist": "^1.8.0",
         "node-stream-zip": "^1.15.0"
       },
@@ -787,6 +787,11 @@
       "bin": {
         "js-yaml": "bin/js-yaml.js"
       }
+    },
+    "node_modules/jsonc-parser": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/jsonc-parser/-/jsonc-parser-3.2.1.tgz",
+      "integrity": "sha512-AilxAyFOAcK5wA1+LeaySVBrHsGQvUFCDWXKpZjzaL0PqW+xfBOttn8GNtWKFWqneyMZj41MWF9Kl6iPWLwgOA=="
     },
     "node_modules/kolorist": {
       "version": "1.8.0",

--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
     "typescript": "^5.3.3"
   },
   "dependencies": {
+    "jsonc-parser": "^3.2.1",
     "kolorist": "^1.8.0",
     "node-stream-zip": "^1.15.0"
   }

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -7,6 +7,7 @@ import {
   fileExists,
   getNewLineChars,
   JsrPackage,
+  Package,
   timeAgo,
 } from "./utils";
 import { Bun, getPkgManager, PkgManagerName, YarnBerry } from "./pkg_manager";
@@ -86,10 +87,10 @@ export interface InstallOptions extends BaseOptions {
   mode: "dev" | "prod" | "optional";
 }
 
-export async function install(packages: JsrPackage[], options: InstallOptions) {
+export async function install(packages: Package[], options: InstallOptions) {
   const pkgManager = await getPkgManager(process.cwd(), options.pkgManagerName);
 
-  if (packages.length > 0) {
+  if (packages.some((pkg) => pkg instanceof JsrPackage)) {
     if (pkgManager instanceof Bun) {
       // Bun doesn't support reading from .npmrc yet
       await setupBunfigToml(pkgManager.cwd);

--- a/test/unit.test.ts
+++ b/test/unit.test.ts
@@ -2,7 +2,7 @@ import * as path from "path";
 import { runInTempDir } from "./test_utils";
 import { setupNpmRc } from "../src/commands";
 import * as assert from "assert/strict";
-import { readTextFile, writeTextFile } from "../src/utils";
+import { NpmPackage, readTextFile, writeTextFile } from "../src/utils";
 
 describe("npmrc", () => {
   it("doesn't overwrite exising jsr mapping", async () => {
@@ -33,5 +33,24 @@ describe("npmrc", () => {
         ].join("\n"),
       );
     });
+  });
+});
+
+describe("NpmPackage", () => {
+  it("parse", () => {
+    assert.equal(NpmPackage.from("foo").toString(), "foo");
+    assert.equal(NpmPackage.from("foo-bar").toString(), "foo-bar");
+    assert.equal(
+      NpmPackage.from("@foo-bar/foo-bar").toString(),
+      "@foo-bar/foo-bar",
+    );
+    assert.equal(
+      NpmPackage.from("@foo-bar@1.0.0").toString(),
+      "@foo-bar@1.0.0",
+    );
+    assert.equal(
+      NpmPackage.from("@foo-bar/baz@1.0.0").toString(),
+      "@foo-bar/baz@1.0.0",
+    );
   });
 });


### PR DESCRIPTION
This option is useful for testing Deno-first JSR packages in Node. Passing this flag installs all `jsr:*` and `npm:*` packages defined in the `"imports"` field as npm package which effectively adds it to `package.json`.