### PR TITLE
feat: set type:module in package.json on install

### DIFF
--- a/src/bin.ts
+++ b/src/bin.ts
@@ -16,8 +16,11 @@ import {
   findProjectDir,
   JsrPackage,
   JsrPackageNameError,
+  PkgJson,
   prettyTime,
+  readJson,
   setDebug,
+  writeJson,
 } from "./utils";
 import { PkgManagerName } from "./pkg_manager";
 
@@ -212,6 +215,21 @@ if (args.length === 0) {
     if (cmd === "i" || cmd === "install" || cmd === "add") {
       run(async () => {
         const packages = getPackages(options.positionals, true);
+        const projectInfo = await findProjectDir(process.cwd());
+
+        if (projectInfo.pkgJsonPath !== null) {
+          const pkgJson = await readJson<PkgJson>(projectInfo.pkgJsonPath);
+          if (pkgJson.type !== "module") {
+            pkgJson.type = "module";
+            await writeJson(
+              projectInfo.pkgJsonPath,
+              pkgJson,
+            );
+            console.log(
+              `Setting type:module in package.json...${kl.green("ok")}`,
+            );
+          }
+        }
 
         await install(packages, {
           mode: options.values["save-dev"]

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -245,6 +245,7 @@ export interface PkgJson {
   name?: string;
   version?: string;
   license?: string;
+  type?: "module" | "commonjs";
 
   dependencies?: Record<string, string>;
   devDependencies?: Record<string, string>;

--- a/test/commands.test.ts
+++ b/test/commands.test.ts
@@ -35,6 +35,8 @@ describe("install", () => {
         /^npm:@jsr\/std__encoding@\^\d+\.\d+\.\d+.*$/,
       );
 
+      assert.equal(pkgJson.type, "module");
+
       const depPath = path.join(dir, "node_modules", "@std", "encoding");
       assert.ok(await isDirectory(depPath), "Not installed in node_modules");
 
@@ -45,7 +47,9 @@ describe("install", () => {
         "Missing npmrc registry",
       );
     });
+  });
 
+  it("jsr i @std/encoding - resolve latest version in yarn berry", async () => {
     await runInTempDir(async (dir) => {
       await enableYarnBerry(dir);
       await writeTextFile(path.join(dir, "yarn.lock"), "");


### PR DESCRIPTION
JSR packages only work with `type: "module"` so it makes sense that the cli tool sets that up automatically for the user.