### PR TITLE
fix: "show" cmd error for packages without stable versions

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7,11 +7,11 @@
     "": {
       "name": "jsr",
       "version": "0.12.3",
-      "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
         "kolorist": "^1.8.0",
-        "node-stream-zip": "^1.15.0"
+        "node-stream-zip": "^1.15.0",
+        "semiver": "^1.1.0"
       },
       "bin": {
         "jsr": "dist/bin.js"
@@ -1117,6 +1117,14 @@
           "url": "https://feross.org/support"
         }
       ]
+    },
+    "node_modules/semiver": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/semiver/-/semiver-1.1.0.tgz",
+      "integrity": "sha512-QNI2ChmuioGC1/xjyYwyZYADILWyW6AmS1UH6gDj/SFUUUS4MBAWs/7mxnkRPc/F4iHezDP+O8t0dO8WHiEOdg==",
+      "engines": {
+        "node": ">=6"
+      }
     },
     "node_modules/serialize-javascript": {
       "version": "6.0.0",

--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
   },
   "dependencies": {
     "kolorist": "^1.8.0",
-    "node-stream-zip": "^1.15.0"
+    "node-stream-zip": "^1.15.0",
+    "semiver": "^1.1.0"
   }
 }

--- a/test/commands.test.ts
+++ b/test/commands.test.ts
@@ -788,4 +788,16 @@ describe("show", () => {
       process.cwd(),
     );
   });
+
+  it("should show package information for pre-release only packages", async () => {
+    const output = await runJsr(
+      ["show", "@fresh/update"],
+      process.cwd(),
+      undefined,
+      true,
+    );
+    const txt = kl.stripColors(output);
+    assert.ok(txt.includes("latest: -"));
+    assert.ok(txt.includes("npm tarball:"));
+  });
 });


### PR DESCRIPTION
This PR fixes an error that was thrown when running the `jsr show <pkg>` command on a package which has no stable versions. In those cases `latest` is not set. We didn't handle that case.

Error:

```sh
$ npx jsr show @fresh/update

TypeError: Cannot read properties of undefined (reading 'dist')
# ...snip
```