### PR TITLE
feat: add `jsr setup` subcommand

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,8 @@ commands.
 - `publish`: Publish `package.json` libraries to JSR.
 - `run <script>`: Run a JSR package script.
 - `<script>`: Run a JSR package script without `run` command.
+- `setup`: Set up the project for JSR. Add the settings for mapping @jsr scope
+  to JSR registry.
 
 ## Limitations
 

--- a/src/bin.ts
+++ b/src/bin.ts
@@ -9,6 +9,7 @@ import {
   publish,
   remove,
   runScript,
+  setup,
   showPackageInfo,
 } from "./commands";
 import {
@@ -237,6 +238,10 @@ if (args.length === 0) {
       }
       run(async () => {
         await runScript(process.cwd(), script, { pkgManagerName });
+      });
+    } else if (cmd === "setup") {
+      run(async () => {
+        await setup({ pkgManagerName });
       });
     } else {
       const packageJsonPath = path.join(process.cwd(), "package.json");

--- a/src/bin.ts
+++ b/src/bin.ts
@@ -59,6 +59,10 @@ ${
       ["r, uninstall, remove", "Remove one or more JSR packages."],
       ["publish", "Publish a package to the JSR registry."],
       ["info, show, view", "Show package information."],
+      [
+        "setup",
+        "Set up the project for JSR. Add the settings for mapping @jsr scope to JSR registry.",
+      ],
     ])
   }
 

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -85,7 +85,7 @@ export async function setupBunfigToml(dir: string) {
   }
 }
 
-/** Sets up `@jsr` scope to map it to npm.jsr.io registry for various package managers. */
+/** Adds settings to map `@jsr` scope to https://npm.jsr.io registry for the given package manager */
 async function setupJsrScope(dir: string, pkgManager: PackageManager) {
   if (pkgManager instanceof Bun) {
     // Bun doesn't support reading from .npmrc yet


### PR DESCRIPTION
This PR adds `jsr setup` subcommand as described in #88. This command should be useful when a user want to install an npm package with JSR dependencies.

closes #88