### PR TITLE
feat: Add npmrc support check for Bun package manager

### DIFF
--- a/src/commands.ts
+++ b/src/commands.ts
@@ -94,8 +94,10 @@ export async function install(packages: JsrPackage[], options: InstallOptions) {
   );
 
   if (packages.length > 0) {
-    if (pkgManager instanceof Bun) {
-      // Bun doesn't support reading from .npmrc yet
+    if (pkgManager instanceof Bun && !(await pkgManager.isNpmrcSupported())) {
+      // Bun v1.1.17 or lower doesn't support reading from .npmrc
+      // Bun v1.1.18+ supports npmrc
+      // https://bun.sh/blog/bun-v1.1.18#npmrc-support
       await setupBunfigToml(root);
     } else if (pkgManager instanceof YarnBerry) {
       // Yarn v2+ does not read from .npmrc intentionally

--- a/src/pkg_manager.ts
+++ b/src/pkg_manager.ts
@@ -184,7 +184,8 @@ export class Bun implements PackageManager {
   }
 
   async isNpmrcSupported() {
-    const version = await exec("bun", ["--version"], this.cwd, undefined, true);
+    const output = await exec("bun", ["--version"], this.cwd, undefined, true);
+    const version = output.stdout;
     // bun v1.1.18 supports npmrc https://bun.sh/blog/bun-v1.1.18#npmrc-support
     return version != null && semiver(version, "1.1.18") >= 0;
   }

--- a/src/pkg_manager.ts
+++ b/src/pkg_manager.ts
@@ -3,6 +3,7 @@ import { getLatestPackageVersion } from "./api";
 import { InstallOptions } from "./commands";
 import { exec, findProjectDir, JsrPackage, logDebug } from "./utils";
 import * as kl from "kolorist";
+import semiver from "semiver";
 
 async function execWithLog(cmd: string, args: string[], cwd: string) {
   console.log(kl.dim(`$ ${cmd} ${args.join(" ")}`));
@@ -180,6 +181,12 @@ export class Bun implements PackageManager {
 
   async runScript(script: string) {
     await execWithLog("bun", ["run", script], this.cwd);
+  }
+
+  async isNpmrcSupported() {
+    const version = await exec("bun", ["--version"], this.cwd, undefined, true);
+    // bun v1.1.18 supports npmrc https://bun.sh/blog/bun-v1.1.18#npmrc-support
+    return version != null && semiver(version, "1.1.18") >= 0;
   }
 }
 

--- a/test/commands.test.ts
+++ b/test/commands.test.ts
@@ -4,6 +4,7 @@ import * as kl from "kolorist";
 import {
   DenoJson,
   enableYarnBerry,
+  isBunSupportNpmrc,
   isDirectory,
   isFile,
   runInTempDir,
@@ -443,8 +444,17 @@ describe("install", () => {
             "bun lockfile not created",
           );
 
-          const config = await readTextFile(path.join(dir, "bunfig.toml"));
-          assert.match(config, /"@jsr"\s+=/, "bunfig.toml not created");
+          if (await isBunSupportNpmrc(dir)) {
+            const npmrcPath = path.join(dir, ".npmrc");
+            const npmRc = await readTextFile(npmrcPath);
+            assert.ok(
+              npmRc.includes("@jsr:registry=https://npm.jsr.io"),
+              "Missing npmrc registry",
+            );
+          } else {
+            const config = await readTextFile(path.join(dir, "bunfig.toml"));
+            assert.match(config, /"@jsr"\s+=/, "bunfig.toml not created");
+          }
         },
       );
     });
@@ -453,8 +463,18 @@ describe("install", () => {
         ["i", "--bun", "@std/encoding@0.216.0"],
         async (dir) => {
           await runJsr(["i", "--bun", "@std/encoding@0.216.0"], dir);
-          const config = await readTextFile(path.join(dir, "bunfig.toml"));
-          assert.match(config, /"@jsr"\s+=/, "bunfig.toml not created");
+
+          if (await isBunSupportNpmrc(dir)) {
+            const npmrcPath = path.join(dir, ".npmrc");
+            const npmRc = await readTextFile(npmrcPath);
+            assert.ok(
+              npmRc.includes("@jsr:registry=https://npm.jsr.io"),
+              "Missing npmrc registry",
+            );
+          } else {
+            const config = await readTextFile(path.join(dir, "bunfig.toml"));
+            assert.match(config, /"@jsr"\s+=/, "bunfig.toml not created");
+          }
         },
       );
     });

--- a/test/commands.test.ts
+++ b/test/commands.test.ts
@@ -4,7 +4,6 @@ import * as kl from "kolorist";
 import {
   DenoJson,
   enableYarnBerry,
-  isBunSupportNpmrc,
   isDirectory,
   isFile,
   runInTempDir,
@@ -21,6 +20,7 @@ import {
   writeJson,
   writeTextFile,
 } from "../src/utils";
+import { Bun } from "../src/pkg_manager";
 
 describe("general", () => {
   it("exit 1 on unknown command", async () => {
@@ -444,7 +444,9 @@ describe("install", () => {
             "bun lockfile not created",
           );
 
-          if (await isBunSupportNpmrc(dir)) {
+          const bun = new Bun(dir);
+
+          if (await bun.isNpmrcSupported()) {
             const npmrcPath = path.join(dir, ".npmrc");
             const npmRc = await readTextFile(npmrcPath);
             assert.ok(
@@ -464,7 +466,8 @@ describe("install", () => {
         async (dir) => {
           await runJsr(["i", "--bun", "@std/encoding@0.216.0"], dir);
 
-          if (await isBunSupportNpmrc(dir)) {
+          const bun = new Bun(dir);
+          if (await bun.isNpmrcSupported()) {
             const npmrcPath = path.join(dir, ".npmrc");
             const npmRc = await readTextFile(npmrcPath);
             assert.ok(

--- a/test/test_utils.ts
+++ b/test/test_utils.ts
@@ -1,6 +1,7 @@
 import * as fs from "node:fs";
 import * as path from "node:path";
 import * as os from "node:os";
+import semiver from "semiver";
 import { exec, writeJson } from "../src/utils";
 
 export interface DenoJson {
@@ -30,6 +31,12 @@ export async function runJsr(
     npm_config_user_agent: undefined,
     ...env,
   }, captureOutput);
+}
+
+export async function isBunSupportNpmrc(cwd: string) {
+  const version = await exec("bun", ["--version"], cwd, undefined, true);
+  // bun v1.1.18 supports npmrc https://bun.sh/blog/bun-v1.1.18#npmrc-support
+  return version != null && semiver(version, "1.1.18") >= 0;
 }
 
 export async function runInTempDir(fn: (dir: string) => Promise<void>) {

--- a/test/test_utils.ts
+++ b/test/test_utils.ts
@@ -33,12 +33,6 @@ export async function runJsr(
   }, captureOutput);
 }
 
-export async function isBunSupportNpmrc(cwd: string) {
-  const version = await exec("bun", ["--version"], cwd, undefined, true);
-  // bun v1.1.18 supports npmrc https://bun.sh/blog/bun-v1.1.18#npmrc-support
-  return version != null && semiver(version, "1.1.18") >= 0;
-}
-
 export async function runInTempDir(fn: (dir: string) => Promise<void>) {
   const dir = await fs.promises.mkdtemp(path.join(os.tmpdir(), "jsr-cli"));
 

--- a/test/test_utils.ts
+++ b/test/test_utils.ts
@@ -1,7 +1,6 @@
 import * as fs from "node:fs";
 import * as path from "node:path";
 import * as os from "node:os";
-import semiver from "semiver";
 import { exec, writeJson } from "../src/utils";
 
 export interface DenoJson {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -6,8 +6,7 @@
     "outDir": "dist/",
     "declaration": true,
     "sourceMap": true,
-    "isolatedModules": true,
-    "esModuleInterop": true
+    "isolatedModules": true
   },
   "include": ["src"]
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -6,7 +6,8 @@
     "outDir": "dist/",
     "declaration": true,
     "sourceMap": true,
-    "isolatedModules": true
+    "isolatedModules": true,
+    "esModuleInterop": true
   },
   "include": ["src"]
 }


### PR DESCRIPTION
This commit introduces a check to determine if the Bun package manager supports npmrc. If the version of Bun is 1.1.18 or higher, it is considered to support npmrc. This information is used to decide whether to create a bunfig.toml file or not. The tests have been updated accordingly to check for either bunfig.toml or .npmrc based on the version of Bun.
fixes: #93