### PR TITLE
fix: switch to deno release binary for publishing by default

### DIFF
--- a/src/bin.ts
+++ b/src/bin.ts
@@ -107,6 +107,10 @@ ${
         "DENO_BIN_PATH",
         "Use specified Deno binary instead of local downloaded one.",
       ],
+      [
+        "DENO_BIN_CANARY",
+        "Use the canary Deno binary instead of latest for publishing.",
+      ],
     ])
   }
 `);
@@ -148,6 +152,7 @@ if (args.length === 0) {
     run(async () => {
       const projectInfo = await findProjectDir(process.cwd());
       return publish(process.cwd(), {
+        canary: process.env.DENO_BIN_CANARY !== undefined,
         binFolder,
         publishArgs: args.slice(1),
         pkgJsonPath: projectInfo.pkgJsonPath,
@@ -185,6 +190,7 @@ if (args.length === 0) {
         pnpm: { type: "boolean", default: false },
         bun: { type: "boolean", default: false },
         debug: { type: "boolean", default: false },
+        canary: { type: "boolean", default: false },
         help: { type: "boolean", default: false, short: "h" },
         version: { type: "boolean", default: false, short: "v" },
       },

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -129,10 +129,11 @@ export interface PublishOptions {
   binFolder: string;
   pkgJsonPath: string | null;
   publishArgs: string[];
+  canary: boolean;
 }
 
-async function getOrDownloadBinPath(binFolder: string) {
-  const info = await getDenoDownloadUrl();
+async function getOrDownloadBinPath(binFolder: string, canary: boolean) {
+  const info = await getDenoDownloadUrl(canary);
 
   const binPath = path.join(
     binFolder,
@@ -164,7 +165,7 @@ async function getOrDownloadBinPath(binFolder: string) {
 
 export async function publish(cwd: string, options: PublishOptions) {
   const binPath = process.env.DENO_BIN_PATH ??
-    await getOrDownloadBinPath(options.binFolder);
+    await getOrDownloadBinPath(options.binFolder, options.canary);
 
   // Ready to publish now!
   const args = [

--- a/src/download.ts
+++ b/src/download.ts
@@ -26,6 +26,7 @@ export interface DownloadInfo {
   url: string;
   filename: string;
   version: string;
+  canary: boolean;
 }
 
 export async function getDenoDownloadUrl(
@@ -52,6 +53,7 @@ export async function getDenoDownloadUrl(
 
   const filename = name + ".zip";
   return {
+    canary,
     url: canary
       ? `https://dl.deno.land/canary/${decodeURI(version)}/${filename}`
       : `https://dl.deno.land/release/${decodeURI(version)}/${filename}`,
@@ -74,7 +76,9 @@ export async function downloadDeno(
     throw new Error(`Unexpected empty body`);
   }
 
-  console.log(`Downloading JSR binary...`);
+  console.log(
+    `Downloading JSR ${info.canary ? "canary" : "release"} binary...`,
+  );
 
   await withProgressBar(
     async (tick) => {

--- a/test/commands.test.ts
+++ b/test/commands.test.ts
@@ -197,7 +197,7 @@ describe("install", () => {
 
       assert.match(
         pkgJson.dependencies["@std/encoding"],
-        /^npm:@jsr\/std__encoding@\d+\.\d+\.\d+.*$/,
+        /^npm:@jsr\/std__encoding@[^]?\d+\.\d+\.\d+.*$/,
       );
 
       const npmRc = await readTextFile(path.join(dir, ".npmrc"));
@@ -751,6 +751,28 @@ describe("publish", () => {
 
         await runJsr(["publish", "--dry-run", "--non-existant-option"], dir, {
           DENO_BIN_PATH: path.join(__dirname, "fixtures", "dummy.js"),
+        });
+      });
+    });
+
+    it("use deno canary binary when DENO_BIN_CANARY when set", async () => {
+      await runInTempDir(async (dir) => {
+        await writeTextFile(
+          path.join(dir, "mod.ts"),
+          "export const value = 42;",
+        );
+
+        // TODO: Change this once deno supports jsr.json
+        await writeJson<DenoJson>(path.join(dir, "deno.json"), {
+          name: "@deno/jsr-cli-test",
+          version: "1.0.0",
+          exports: {
+            ".": "./mod.ts",
+          },
+        });
+
+        await runJsr(["publish", "--dry-run"], dir, {
+          DENO_BIN_CANARY: "true",
         });
       });
     });


### PR DESCRIPTION
This adds a new `DENO_BIN_CANARY` environment variable check to use the canary binary instead as well.

Fixes https://github.com/jsr-io/jsr-npm/issues/99