### PR TITLE
add support for deno.json and deno-workspaces

### DIFF
--- a/src/pkg_manager.ts
+++ b/src/pkg_manager.ts
@@ -191,7 +191,7 @@ export class Bun implements PackageManager {
   }
 }
 
-export type PkgManagerName = "npm" | "yarn" | "pnpm" | "bun";
+export type PkgManagerName = "npm" | "yarn" | "pnpm" | "bun" | "deno";
 
 function getPkgManagerFromEnv(value: string): PkgManagerName | null {
   if (value.startsWith("pnpm/")) return "pnpm";

--- a/test/utils.test.ts
+++ b/test/utils.test.ts
@@ -5,6 +5,7 @@ import {
   findProjectDir,
   JsrPackage,
   PkgJson,
+  DenoJson,
   writeJson,
   writeTextFile,
 } from "../src/utils";
@@ -80,6 +81,21 @@ describe("findProjectDir", () => {
         workspaces: ["sub"],
       });
       await writeJson(path.join(sub, "package.json"), {});
+      const result = await findProjectDir(sub);
+      assert.strictEqual(
+        result.root,
+        tempDir,
+      );
+    });
+  });
+
+
+  it("should find deno workspace root folder", async () => {
+    await runInTempDir(async (tempDir) => {
+      const sub = path.join(tempDir, "sub");
+
+      await writeJson<DenoJson>(path.join(tempDir, "deno.json"), { workspace: ["./sub"] });
+      await writeJson(path.join(sub, "deno.json"), {});
       const result = await findProjectDir(sub);
       assert.strictEqual(
         result.root,


### PR DESCRIPTION
I am using a Vite project in a deno workspace and therefore need to have jsr packages installed in the node_modules folder so that Vite can find them for bundling.

I noticed that when I run `npx jsr add @std/fmt` inside my sub-package, the `.npmrc` file is generated in the sub-package instead of the root (where i belongs), leading to npm error 404 errors because npx doesn't find the registry.

Workspace-root detection has already been implemented for Yarn and pnpm workspaces, and this PR adds support for a Deno workspace.

Not so happy with the duped .jsonc code rn.
I'm happy to hear your feedback!
