### PR TITLE
fix: drop unsupported `--provenance` from help

### DIFF
--- a/src/bin.ts
+++ b/src/bin.ts
@@ -94,8 +94,8 @@ ${
       ],
       ["--allow-slow-types", "Allow publishing with slow types."],
       [
-        "--provenance",
-        "From CI/CD system, publicly links the package to where it was built and published from.",
+        "--no-provenance",
+        "Disable provenance attestation. Enabled by default on GitHub Actions.",
       ],
     ])
   }


### PR DESCRIPTION
`jsr publish --help` advertises `--provenance`, but passing it crashes. Publish
args are forwarded verbatim to the bundled `deno publish`, which only accepts
`--no-provenance`:

```
$ jsr publish --dry-run --provenance
error: unexpected argument '--provenance' found

  tip: a similar argument exists: '--no-provenance'
```

Closes #151.
